### PR TITLE
cgo CXXFLAGS:  Explicitly set c++ standard to 3.0

### DIFF
--- a/cld2_nlpt.go
+++ b/cld2_nlpt.go
@@ -17,8 +17,11 @@
 
 package cld2_nlpt
 
-// #include <stdlib.h>
-// #include "cld2_nlpt.h"
+/*
+#cgo CXXFLAGS: -std=c++03
+#include <stdlib.h>
+#include "cld2_nlpt.h"
+*/
 import "C"
 
 import (


### PR DESCRIPTION
Newer versions of the C++ standard generate the following error:

```
cld_generated_cjk_uni_prop_80.cc:7089:1: error: narrowing conversion of ‘-9’ from ‘int’ to ‘CLD2::uint8 {aka unsigned char}’ inside { } [-Wnarrowing]
```

This patch fixes the standard to 3.0, allowing builds to continue, but leaves this apparently valid error unaddressed.

Kindest regards
